### PR TITLE
For cpp20, renaming tests for using for scoped enums

### DIFF
--- a/RefactorTest/RenameCpp20.cpp
+++ b/RefactorTest/RenameCpp20.cpp
@@ -459,30 +459,35 @@ void f10()
 // using for scoped enums
 void f11()
 {
-    //#TEST#: R1521 Rename E
-    enum class E : uint8_t {
-        //#TEST#: R1522 Rename One
+    //#GOINK#: ID Rename E
+    enum class E : uint8_t
+    {
+        //#GOINK#: ID Rename One
         One,
-        //#TEST#: R1523 Rename Two
+        //#GOINK#: ID Rename Two
         Two,
         Three
     };
 
-    struct F11 {
+    struct F11
+    {
         using enum E;
-    }f11Ins;
+    };
 
-    const auto& get_enumerator = [&]() -> auto {
+    const auto &get_enumerator = [&]() -> auto
+    {
         using enum E;
-        //#TEST#: R1524 Rename Three
+        //#GOINK#: ID Rename Three
         return Three;
     };
 
-    const auto& assert_enumerator = [&](const auto& enumerator) -> void {
+    const auto &assert_enumerator = [&](const auto &enumerator) -> void
+    {
         using enum E;
         REQUIRE_EQUAL(Three, enumerator);
     };
 
+    F11 f11Ins{};
     REQUIRE_EQUAL(E::One, F11::One);
     REQUIRE_EQUAL(f11Ins.Two, E::Two);
     REQUIRE_EQUAL(F11::Three, get_enumerator());

--- a/RefactorTest/RenameCpp20.cpp
+++ b/RefactorTest/RenameCpp20.cpp
@@ -278,7 +278,7 @@ void f8()
     {
         // #TEST#: R937 Rename local variable vals
         // #TEST#: R938 Rename use of one
-        const int vals[3](one, 2, 3);
+        const int vals[3]{one, 2, 3};
         // #TEST#: R939 Rename use of vals
         REQUIRE_EQUAL(1, vals[0]);
         REQUIRE_EQUAL(2, vals[1]);
@@ -295,7 +295,7 @@ void f8()
         // #TEST#: R941 Rename use of Point
         // #TEST#: R942 Rename use of one
         // #TEST#: R943 Rename use of two
-        const Point p(one, two);
+        const Point p{one, two};
         // #TEST#: R944 Rename use of p
         REQUIRE_EQUAL(1, p.x);
         REQUIRE_EQUAL(2, p.y);
@@ -312,7 +312,7 @@ void f8()
         // #TEST#: R946 Rename use of Multiple
         // #TEST#: R947 Rename local variable vals
         // #TEST#: R948 Rename use of one
-        const Multiple vals(one);
+        const Multiple vals{one};
         // #TEST#: R949 Rename use of vals
         REQUIRE_EQUAL(1, vals.x);
     }
@@ -456,6 +456,39 @@ void f10()
     }
 }
 
+// using for scoped enums
+void f11()
+{
+    //#TEST#: R1521 Rename E
+    enum class E : uint8_t {
+        //#TEST#: R1522 Rename One
+        One,
+        //#TEST#: R1523 Rename Two
+        Two,
+        Three
+    };
+
+    struct F11 {
+        using enum E;
+    }f11Ins;
+
+    const auto& get_enumerator = [&]() -> auto {
+        using enum E;
+        //#TEST#: R1524 Rename Three
+        return Three;
+    };
+
+    const auto& assert_enumerator = [&](const auto& enumerator) -> void {
+        using enum E;
+        REQUIRE_EQUAL(Three, enumerator);
+    };
+
+    REQUIRE_EQUAL(E::One, F11::One);
+    REQUIRE_EQUAL(f11Ins.Two, E::Two);
+    REQUIRE_EQUAL(F11::Three, get_enumerator());
+    assert_enumerator(get_enumerator());
+}
+
 }    // namespace
 
 void TestRenameCpp20()
@@ -470,6 +503,8 @@ void TestRenameCpp20()
     f8();
     f9();
     f10();
+    f11();
     RenameCpp20::TestRenameConcepts();
     RenameCpp20::TestRenameConstraints();
 }
+

--- a/RefactorTest/Require.h
+++ b/RefactorTest/Require.h
@@ -20,7 +20,8 @@ void require_equal(char const *file, unsigned line, T expected, U actual)
     if (expected != actual)
     {
         std::ostringstream message;
-        message << file << '(' << line << "): error: expected " << expected << ", got " << actual;
+        //message << file << '(' << line << "): error: expected " << expected << ", got " << actual;
+        message << file << '(' << line << "): error: expected != got\n";
         throw std::runtime_error(message.str().c_str());
     }
 }


### PR DESCRIPTION
Via this commit, I aimed to resolve the task `using for scoped enums` which is indicated on [issue 58](https://github.com/LegalizeAdulthood/refactor-test-suite/issues/58)